### PR TITLE
switch image to openresty official

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,6 +2,8 @@
 
 set -eux
 
+apt update
+apt install -y build-essential && cpan -T -i Test::Nginx
 pushd libcidr-git
   make
   make install

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -4,7 +4,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: talentappstore/openresty-test
+    repository: openresty/openresty
+    tag: buster-fat
 
 inputs:
 - name: secureproxy-release-git-repo


### PR DESCRIPTION
## Changes Proposed
- Switch test image to openresty official image
- add dependencies for testing during testing. Ideally we'd create a test image, but this is enough to get us working for now

## Security Considerations

Gets us back to a point where we can iterate on and test this release as needed