### PR TITLE
moving openresty and logic to support bionic

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ libcidr/libcidr-1.2.3.tar.xz:
   size: 155144
   object_id: 8af20069-a5f3-43d3-7ef8-268b21085f5c
   sha: 092bf19ff2b3b3765fc002710d2cd1842ae5baae
-openresty-1.11.2.4.tar.gz:
-  size: 4158984
-  object_id: 0997edac-1c09-4778-65d1-e9af9c220122
-  sha: 7449c57cf53e3ac963736b7e0333c929688b5bfc
+openresty-1.13.6.2.tar.gz:
+  size: 4635916
+  object_id: 8c7d1f6b-507f-4e47-6100-7169a3f89662
+  sha: sha256:946e1958273032db43833982e2cec0766154a9b5cb8e67868944113208ff2942
 pcre-8.41.tar.gz:
   size: 2068775
   object_id: 3e897822-0a33-4fca-7177-38956963eeaa

--- a/packages/secureproxy/packaging
+++ b/packages/secureproxy/packaging
@@ -8,14 +8,40 @@ echo "Extracting nginx..."
 OPENRESTY_TARGET=$(mktemp -d)
 tar xzvf openresty-1* -C ${OPENRESTY_TARGET}
 
-echo "Building nginx..."
-pushd ${OPENRESTY_TARGET}/openresty*
-  ./configure \
-    --prefix=${BOSH_INSTALL_TARGET} \
-    --with-pcre=${PCRE_TARGET}/pcre*
-  make
-  make install
-popd
+codename=$(lsb_release -sc)
+case "$codename" in
+xenial)
+  echo "Runnng $codename packaging script"
+  (
+  echo "Building nginx..."
+  pushd ${OPENRESTY_TARGET}/openresty*
+    ./configure \
+      --prefix=${BOSH_INSTALL_TARGET} \
+      --with-pcre=${PCRE_TARGET}/pcre*
+    make
+    make install
+  popd
+  )
+  ;;
+bionic)
+  echo "Runnng $codename packaging script"
+  (
+  echo "Building nginx..."
+  pushd ${OPENRESTY_TARGET}/openresty*
+    ./configure \
+      --prefix=${BOSH_INSTALL_TARGET} \
+      --with-pcre \
+      --with-pcre-jit
+    make
+    make install
+  popd  )
+  ;;
+*)
+  echo "This version of the BOSH Stemcell ($codename) is not supported!"
+  lsb_release --all | sed -e 's/^/  /'
+  exit 1
+  ;;
+esac
 
 echo "Adding libcidr-ffi..."
 # TODO: PR OPM to support installing modules from local sources


### PR DESCRIPTION
## Changes Proposed

- Adding packing logic to split between Xenial and Bionic - each have different PCRE requirements
- Moved Openresty to 1.13.6.2 from 1.11.2.4 - release 1.13 is min to run Openresty on Bionic and last release to support Xenial
-

## Security Considerations

- This allows use of the release on Bionic so we can move forward and reduce CVE from Xenial
