### PR TITLE
Cut Https release

### DIFF
--- a/jobs/secureproxy/spec
+++ b/jobs/secureproxy/spec
@@ -15,11 +15,11 @@ templates:
   bin/drain: bin/drain
 
 properties:
-  secureproxy.http_listen_port:
+  secureproxy.listen_port:
     description: Listen to this port via HTTP
   secureproxy.https_listen_port:
     description: Listen to this port via HTTPS
-  secureproxy.http_proxy_port:
+  secureproxy.proxy_port:
     description: HTTP proxy to this port
   secureproxy.https_proxy_port:
     description: HTTPS proxy to this port

--- a/jobs/secureproxy/spec
+++ b/jobs/secureproxy/spec
@@ -15,12 +15,15 @@ templates:
   bin/drain: bin/drain
 
 properties:
-  secureproxy.listen_port:
-    description: Listen to this port
-  secureproxy.http_proxy:
-    description: Have secureproxy default to HTTP front to back
-  secureproxy.proxy_port:
-    description: Proxy to this port
+  secureproxy.http_listen_port:
+    description: Listen to this port via HTTP
+  secureproxy.https_listen_port:
+    description: Listen to this port via HTTPS
+  secureproxy.http_proxy_port:
+    description: HTTP proxy to this port
+  secureproxy.https_proxy_port:
+    description: HTTPS proxy to this port
+
 
   secureproxy.tls_cert:
     description: Cert file for nginx to use for SSL front end

--- a/jobs/secureproxy/spec
+++ b/jobs/secureproxy/spec
@@ -7,6 +7,8 @@ templates:
   bin/monit_debugger: bin/monit_debugger
   bin/secureproxy_ctl: bin/secureproxy_ctl
   config/nginx.conf.erb: config/nginx.conf
+  config/cert.crt.erb: config/cert.crt
+  config/priv.key.erb: config/priv.key
   config/ip_whitelist.lua.erb: config/ip_whitelist.lua
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
@@ -15,8 +17,16 @@ templates:
 properties:
   secureproxy.listen_port:
     description: Listen to this port
+  secureproxy.http_proxy:
+    description: Have secureproxy default to HTTP front to back
   secureproxy.proxy_port:
     description: Proxy to this port
+
+  secureproxy.tls_cert:
+    description: Cert file for nginx to use for SSL front end
+  secureproxy.tls_key:
+    description: Key file for nginx to use for SSL front end
+
   secureproxy.custom_server_config:
     description: Custom nginx configuration to include in main http block
     default: ""

--- a/jobs/secureproxy/templates/config/cert.crt.erb
+++ b/jobs/secureproxy/templates/config/cert.crt.erb
@@ -1,0 +1,1 @@
+<%= p("secureproxy.tls_cert") %>

--- a/jobs/secureproxy/templates/config/cert.crt.erb
+++ b/jobs/secureproxy/templates/config/cert.crt.erb
@@ -1,3 +1,5 @@
-<% if_p("secureproxy.tls_cert") do |tls_cert|
-    <% tls_cert %>
+<% if_p("secureproxy.tls_cert") do |tls_certs| %>
+<% tls_certs.each do |tls_cert| %>
+<%= tls_cert %>
+<% end %>
 <% end %>

--- a/jobs/secureproxy/templates/config/cert.crt.erb
+++ b/jobs/secureproxy/templates/config/cert.crt.erb
@@ -1,1 +1,3 @@
-<%= p("secureproxy.tls_cert") %>
+<% if_p("secureproxy.tls_cert") do |tls_cert|
+    <% tls_cert %>
+<% end %>

--- a/jobs/secureproxy/templates/config/cert.crt.erb
+++ b/jobs/secureproxy/templates/config/cert.crt.erb
@@ -1,5 +1,3 @@
-<% if_p("secureproxy.tls_cert") do |tls_certs| %>
-<% tls_certs.each do |tls_cert| %>
+<% if_p("secureproxy.tls_cert") do |tls_cert| %>
 <%= tls_cert %>
-<% end %>
 <% end %>

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -209,7 +209,7 @@ http {
 
     <% if_p('secureproxy.proxy_port') do
       fastcgi_param               HTTP_PROXY "";
-    else
+    end.else do
       fastcgi_param               HTTPS_PROXY "";
     end %>
 

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -129,20 +129,16 @@ http {
 
   server {
 
-<% if_p("secureproxy.listen_port") do |http_ports| %>
-    <% http_ports.each do |http_port| %>
+<% if_p("secureproxy.listen_port") do |http_port| %>
     listen <%= http_port %>;
     set $local_proxy "http://127.0.0.1:<%= p("secureproxy.proxy_port") %>";
-    <% end %>
 <% end %>
 
-<% if_p("secureproxy.https_listen_port") do |https_ports| %>
-    <% https_ports.each do |https_port| %>
+<% if_p("secureproxy.https_listen_port") do |https_port| %>
     listen <%= https_port %> ssl;
     ssl_certificate cert.crt;
     ssl_certificate_key priv.key;
     set $local_proxy "https://127.0.0.1:<%= p("secureproxy.https_proxy_port") %>";
-    <% end %>
 <% end %>
 
     server_name  _;

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -128,8 +128,16 @@ http {
   }
 
   server {
+  if_p('secureproxy.http_proxy') do
     listen <%= p("secureproxy.listen_port") %>;
     set $local_proxy "http://127.0.0.1:<%= p("secureproxy.proxy_port") %>";
+  else
+    listen <%= p("secureproxy.listen_port") %> ssl;
+    ssl_certificate cert.crt;
+    ssl_certificate_key priv.key;
+    set $local_proxy "https://127.0.0.1:<%= p("secureproxy.proxy_port") %>";
+  end
+
 
     server_name  _;
     more_clear_headers 'Server';
@@ -197,7 +205,11 @@ http {
         end
       }
 
+    if_p('secureproxy.http_proxy') do
       fastcgi_param               HTTP_PROXY "";
+    else
+      fastcgi_param               HTTPS_PROXY "";
+    end
 
       proxy_buffering             off;
       proxy_buffer_size           16k;

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -207,11 +207,11 @@ http {
         end
       }
 
-    <% if_p('secureproxy.proxy_port') do
+    <% if p('secureproxy.proxy_port') %>
       fastcgi_param               HTTP_PROXY "";
-    end.else do
+    <% else %>
       fastcgi_param               HTTPS_PROXY "";
-    end %>
+    <% end %>
 
       proxy_buffering             off;
       proxy_buffer_size           16k;

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -127,7 +127,7 @@ http {
     ngx.log(ngx.NOTICE, cjson.encode(ip_whitelist))
   }
 
-<% if p('secureproxy.listen_port') %>
+<% if_p("secureproxy.listen_port") do |httpconfig| %>
   server {
 
     listen <%= p("secureproxy.listen_port") %>;
@@ -220,7 +220,7 @@ http {
 
 <% end %>
 
-<% if p('secureproxy.https_listen_port') %>
+<% if_p("secureproxy.listen_port") do |httpsconfig| %>
 server {
 
   listen <%= p("secureproxy.https_listen_port") %> ssl;

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -128,14 +128,17 @@ http {
   }
 
   server {
-  if_p('secureproxy.http_proxy') do
-    listen <%= p("secureproxy.listen_port") %>;
-    set $local_proxy "http://127.0.0.1:<%= p("secureproxy.proxy_port") %>";
-  else
-    listen <%= p("secureproxy.listen_port") %> ssl;
+
+  if_p('secureproxy.http_listen_port') do
+    listen <%= p("secureproxy.http_listen_port") %>;
+    set $local_proxy "http://127.0.0.1:<%= p("secureproxy.http_proxy_port") %>";
+  end
+
+  if_p('secureproxy.https_listen_port') do
+    listen <%= p("secureproxy.https_listen_port") %> ssl;
     ssl_certificate cert.crt;
     ssl_certificate_key priv.key;
-    set $local_proxy "https://127.0.0.1:<%= p("secureproxy.proxy_port") %>";
+    set $local_proxy "https://127.0.0.1:<%= p("secureproxy.https_proxy_port") %>";
   end
 
 
@@ -205,7 +208,7 @@ http {
         end
       }
 
-    if_p('secureproxy.http_proxy') do
+    if_p('secureproxy.http_proxy_port') do
       fastcgi_param               HTTP_PROXY "";
     else
       fastcgi_param               HTTPS_PROXY "";

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -129,16 +129,20 @@ http {
 
   server {
 
-<% if_p("secureproxy.listen_port") do |http_port|
+<% if_p("secureproxy.listen_port") do |http_ports| %>
+    <% http_ports.each do |http_port| %>
     listen <%= http_port %>;
     set $local_proxy "http://127.0.0.1:<%= p("secureproxy.proxy_port") %>";
+    <% end %>
 <% end %>
 
-<% if_p("secureproxy.https_listen_port") do |https_port|
+<% if_p("secureproxy.https_listen_port") do |https_ports| %>
+    <% https_ports.each do |https_port| %>
     listen <%= https_port %> ssl;
     ssl_certificate cert.crt;
     ssl_certificate_key priv.key;
     set $local_proxy "https://127.0.0.1:<%= p("secureproxy.https_proxy_port") %>";
+    <% end %>
 <% end %>
 
     server_name  _;

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -129,9 +129,9 @@ http {
 
   server {
 
-  if_p('secureproxy.http_listen_port') do
-    listen <%= p("secureproxy.http_listen_port") %>;
-    set $local_proxy "http://127.0.0.1:<%= p("secureproxy.http_proxy_port") %>";
+  if_p('secureproxy.listen_port') do
+    listen <%= p("secureproxy.listen_port") %>;
+    set $local_proxy "http://127.0.0.1:<%= p("secureproxy.proxy_port") %>";
   end
 
   if_p('secureproxy.https_listen_port') do
@@ -208,7 +208,7 @@ http {
         end
       }
 
-    if_p('secureproxy.http_proxy_port') do
+    if_p('secureproxy.proxy_port') do
       fastcgi_param               HTTP_PROXY "";
     else
       fastcgi_param               HTTPS_PROXY "";

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -129,8 +129,6 @@ http {
 
   server {
 
-% if_p("some.property") do |prop| %>...<% end %>
-
 <% if_p("secureproxy.listen_port") do |http_port|
     listen <%= http_port %>;
     set $local_proxy "http://127.0.0.1:<%= p("secureproxy.proxy_port") %>";

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -127,20 +127,11 @@ http {
     ngx.log(ngx.NOTICE, cjson.encode(ip_whitelist))
   }
 
+<% if p('secureproxy.listen_port') %>
   server {
 
-<% if_p("secureproxy.listen_port") do |http_port| %>
-    listen <%= http_port %>;
+    listen <%= p("secureproxy.listen_port") %>;
     set $local_proxy "http://127.0.0.1:<%= p("secureproxy.proxy_port") %>";
-<% end %>
-
-<% if_p("secureproxy.https_listen_port") do |https_port| %>
-    listen <%= https_port %> ssl;
-    ssl_certificate cert.crt;
-    ssl_certificate_key priv.key;
-    set $local_proxy "https://127.0.0.1:<%= p("secureproxy.https_proxy_port") %>";
-<% end %>
-
     server_name  _;
     more_clear_headers 'Server';
 
@@ -207,11 +198,7 @@ http {
         end
       }
 
-    <% if p('secureproxy.proxy_port') %>
       fastcgi_param               HTTP_PROXY "";
-    <% else %>
-      fastcgi_param               HTTPS_PROXY "";
-    <% end %>
 
       proxy_buffering             off;
       proxy_buffer_size           16k;
@@ -230,6 +217,104 @@ http {
     }
 
   }
+
+<% end %>
+
+<% if p('secureproxy.https_listen_port') %>
+server {
+
+  listen <%= p("secureproxy.https_listen_port") %> ssl;
+  ssl_certificate cert.crt;
+  ssl_certificate_key priv.key;
+  set $local_proxy "https://127.0.0.1:<%= p("secureproxy.https_proxy_port") %>";
+  server_name  _;
+  more_clear_headers 'Server';
+
+  # proxy all traffic
+  location / {
+
+    # redirect all http traffic to https
+    if ($http_x_forwarded_proto = http) {
+      return 301 https://$host$request_uri;
+    }
+
+    ##
+    # Security
+    ##
+
+    add_header Strict-Transport-Security $sts always;
+    add_header X-Content-Type-Options $content_type_options always;
+    add_header X-XSS-Protection $xss_protection always;
+    add_header Content-Type $default_content_type always;
+
+    # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
+    more_clear_headers X-Frame-Options;
+    more_set_headers "X-Frame-Options: $frame_options";
+
+    ##
+    # Implement per-domain IP Whitelist
+    ##
+
+    access_by_lua_block {
+      -- bail fast if we don't have a whitelist
+      if ip_whitelist_size == 0 then
+        return
+      end
+
+      local opts = {
+        ip_whitelist=ip_whitelist,
+        proxy_whitelist=proxy_whitelist,
+        host_whitelist=host_whitelist,
+        request_uri=ngx.var.request_uri,
+        source_ip=ngx.var.remote_addr,
+        headers=ngx.req.get_headers()
+      }
+
+      <% if_p('secureproxy.tic.secret') do |secret| %>
+      opts.tic_secret = "<%= secret %>"
+      <% end %>
+
+      allow, filtered, source_ip, email = tic.check_ingress(opts)
+
+      if not filtered then
+        return
+      end
+      if allow then
+        ngx.log(ngx.NOTICE, "PASS ", source_ip, " is in ", email[2], " whitelist (", email[1], email[2], ")")
+        return
+      else
+        -- fail if the request isn't coming from a whitelisted range
+        ngx.log(ngx.NOTICE, "FAIL ", source_ip, " is not in ", email[2], " whitelist (", email[1], email[2], ")")
+        ngx.status = ngx.HTTP_FORBIDDEN
+        ngx.header.content_type = "application/json; charset=utf-8"
+        -- TODO: Should we be more informative in our error message, should we use a stock cloud controller error code
+        ngx.say(cjson.encode({description="Authorization Error", error_code="SecureProxy-NotAuthorized", code=9162}))
+        return ngx.exit(ngx.HTTP_FORBIDDEN)
+      end
+    }
+
+    fastcgi_param               HTTPS_PROXY "";
+
+    proxy_buffering             off;
+    proxy_buffer_size           16k;
+    proxy_buffers               4 16k;
+    proxy_http_version          1.1;
+    proxy_set_header            Upgrade $http_upgrade;
+    proxy_set_header            Connection $connection_upgrade;
+    proxy_set_header            Host $host;
+    proxy_set_header            Proxy "";
+    proxy_redirect              off;
+    proxy_pass_request_headers  on;
+    proxy_connect_timeout       10;
+    proxy_read_timeout          600;
+    proxy_pass                  $local_proxy;
+
+  }
+
+}
+<% end %>
+
+
 
   <%= p("secureproxy.custom_server_config") %>
 

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -129,18 +129,19 @@ http {
 
   server {
 
-  if_p('secureproxy.listen_port') do
-    listen <%= p("secureproxy.listen_port") %>;
-    set $local_proxy "http://127.0.0.1:<%= p("secureproxy.proxy_port") %>";
-  end
+% if_p("some.property") do |prop| %>...<% end %>
 
-  if_p('secureproxy.https_listen_port') do
-    listen <%= p("secureproxy.https_listen_port") %> ssl;
+<% if_p("secureproxy.listen_port") do |http_port|
+    listen <%= http_port %>;
+    set $local_proxy "http://127.0.0.1:<%= p("secureproxy.proxy_port") %>";
+<% end %>
+
+<% if_p("secureproxy.https_listen_port") do |https_port|
+    listen <%= https_port %> ssl;
     ssl_certificate cert.crt;
     ssl_certificate_key priv.key;
     set $local_proxy "https://127.0.0.1:<%= p("secureproxy.https_proxy_port") %>";
-  end
-
+<% end %>
 
     server_name  _;
     more_clear_headers 'Server';

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -220,7 +220,7 @@ http {
 
 <% end %>
 
-<% if_p("secureproxy.listen_port") do |httpsconfig| %>
+<% if_p("secureproxy.https_listen_port") do |httpsconfig| %>
 server {
 
   listen <%= p("secureproxy.https_listen_port") %> ssl;

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -207,11 +207,11 @@ http {
         end
       }
 
-    if_p('secureproxy.proxy_port') do
+    <% if_p('secureproxy.proxy_port') do
       fastcgi_param               HTTP_PROXY "";
     else
       fastcgi_param               HTTPS_PROXY "";
-    end
+    end %>
 
       proxy_buffering             off;
       proxy_buffer_size           16k;

--- a/jobs/secureproxy/templates/config/priv.key.erb
+++ b/jobs/secureproxy/templates/config/priv.key.erb
@@ -1,3 +1,5 @@
-<% if_p("secureproxy.tls_key") do |tls_key|
-    <% tls_key %>
+<% if_p("secureproxy.tls_key") do |tls_keys| %>
+<% tls_keys.each do |tls_key| %>
+<%= tls_key %>
+<% end %>
 <% end %>

--- a/jobs/secureproxy/templates/config/priv.key.erb
+++ b/jobs/secureproxy/templates/config/priv.key.erb
@@ -1,1 +1,3 @@
-<%= p("secureproxy.tls_key") %>
+<% if_p("secureproxy.tls_key") do |tls_key|
+    <% tls_key %>
+<% end %>

--- a/jobs/secureproxy/templates/config/priv.key.erb
+++ b/jobs/secureproxy/templates/config/priv.key.erb
@@ -1,0 +1,1 @@
+<%= p("secureproxy.tls_key") %>

--- a/jobs/secureproxy/templates/config/priv.key.erb
+++ b/jobs/secureproxy/templates/config/priv.key.erb
@@ -1,5 +1,3 @@
-<% if_p("secureproxy.tls_key") do |tls_keys| %>
-<% tls_keys.each do |tls_key| %>
+<% if_p("secureproxy.tls_key") do |tls_key| %>
 <%= tls_key %>
-<% end %>
 <% end %>


### PR DESCRIPTION
## Changes Proposed

- Logic added to release to stay HTTP by default
- Logic added to release to support the front end going to SSL
- Logic added to release to support proxy backend using SSL
-Logic added so release can support HTTP and HTTPS at the same time during transition

## Security Considerations

By moving the release to support HTTPS through proxy, we can keep TLS in place as we cross the proxy
