### PR TITLE
fix nginx logic

### DIFF
--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -17,7 +17,7 @@ events {
   report_only = p('secureproxy.csp.report_only')
   if report_only
     csp_header = 'content-security-policy-report-only'
-    csp_header_ref = 'http_content_security_policy_report_only'
+    csp_header_ref = 'upstream_http_content_security_policy_report_only'
   end
 %>
 http {
@@ -109,17 +109,17 @@ http {
   # right now, we're doing this with report-only. later, we'll drop report-only and move to enforce with report
   map $<%= csp_header_ref %> $new_content_security_policy {
     # set the policy if it's unset
-    "" "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; report-uri '<%= p('secureproxy.csp.report_uri') %>';";
+    "" "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; object-src 'none'; report-uri '<%= p('secureproxy.csp.report_uri') %>';";
     default $<%= csp_header_ref %>;
   }
 
-  map $host $new_content_security_policy {
+  map $host $content_security_policy {
     # set it to our modified value if it's one of our hosts
     <% p('secureproxy.csp.host_patterns').each do |host_pattern| %>
-    '<%= host_pattern %>' '$new_content_security_policy';
+    '<%= host_pattern %>' $new_content_security_policy;
     <% end %>
     # don't mess with anyone else's csp
-    default $http_content_security_policy_report_only;
+    default $<%= csp_header_ref %>;
   }
   <% end %>
 
@@ -184,6 +184,11 @@ http {
       # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
       more_clear_headers X-Frame-Options;
       more_set_headers "X-Frame-Options: $frame_options";
+      <% if p('secureproxy.csp.enable') %>
+      # we need to clear the header because doubling headers creates the strictest combination of them
+      more_clear_headers <%= csp_header %>;
+      more_set_headers "<%= csp_header %>: $content_security_policy";
+      <% end %>
 
       ##
       # Implement per-domain IP Whitelist
@@ -283,7 +288,7 @@ server {
     <% if p('secureproxy.csp.enable') %>
     # we need to clear the header because doubling headers creates the strictest combination of them
     more_clear_headers <%= csp_header %>;
-    more_set_headers "<%= csp_header %> $new_content_security_policy";
+    more_set_headers "<%= csp_header %>: $content_security_policy";
     <% end %>
     ##
     # Implement per-domain IP Whitelist


### PR DESCRIPTION

## Changes Proposed

- nginx config does not run top-to-bottom, so stop reusing variable names
- fix header reference name - we need upstream_http_... since we want the response header
- use header reference name everywhere so we correctly control report-only and enforced headers
- add missing colon on more_set_headers directive
- add csp logic into http endpoint

## Security Considerations

iterate on better security, but no direct impacts in this PR