### PR TITLE
get libcidr tarball from package manager to fix tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -79,14 +79,6 @@ resources:
     region_name: ((aws-region))
     server_side_encryption: AES256
 
-- name: libcidr-tarball
-  type: s3-iam
-  source:
-    bucket: s3-blobstore-bucket
-    versioned_file: 8af20069-a5f3-43d3-7ef8-268b21085f5c
-    region_name: ((aws-region))
-    server_side_encryption: AES256
-
 resource_types:
 
 - name: s3-iam

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -55,12 +55,6 @@ resources:
     branch: ((secureproxy-release-git-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
-- name: libcidr-tarball
-  type: file-url
-  source:
-    url: https://www.over-yonder.net/~fullermd/projects/libcidr/libcidr-1.2.3.tar.xz
-    filename: libcidr-1.2.3.tar.xz
-
 - name: secureproxy-release-tarball
   type: s3-iam
   source:
@@ -85,12 +79,15 @@ resources:
     region_name: ((aws-region))
     server_side_encryption: AES256
 
-resource_types:
-- name: file-url
-  type: docker-image
+- name: libcidr-tarball
+  type: s3-iam
   source:
-    repository: pivotalservices/concourse-curl-resource
-    tag: latest
+    bucket: s3-blobstore-bucket
+    versioned_file: 8af20069-a5f3-43d3-7ef8-268b21085f5c
+    region_name: ((aws-region))
+    server_side_encryption: AES256
+
+resource_types:
 
 - name: s3-iam
   type: docker-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -5,7 +5,6 @@ jobs:
   - in_parallel:
     - get: secureproxy-release-git-repo
       trigger: true
-    - get: libcidr-tarball
   - task: test
     file: secureproxy-release-git-repo/ci/test.yml
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -5,7 +5,7 @@ jobs:
   - in_parallel:
     - get: secureproxy-release-git-repo
       trigger: true
-    - get: libcidr-git
+    - get: libcidr-tarball
   - task: test
     file: secureproxy-release-git-repo/ci/test.yml
 
@@ -55,11 +55,11 @@ resources:
     branch: ((secureproxy-release-git-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
-- name: libcidr-git
-  type: git
+- name: libcidr-tarball
+  type: file-url
   source:
-    uri: https://github.com/wikimedia/analytics-libcidr.git
-    branch: master
+    url: https://www.over-yonder.net/~fullermd/projects/libcidr/libcidr-1.2.3.tar.xz
+    filename: libcidr-1.2.3.tar.xz
 
 - name: secureproxy-release-tarball
   type: s3-iam

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -7,7 +7,7 @@ export PERL_MM_USE_DEFAULT=1
 apt install -y build-essential && cpan -T -i Test::Nginx
 
 tar xvf libcidr-tarball/libcidr-1.2.3.tar.xz
-pushd libcidr-tarball
+pushd libcidr-1.2.3
   make
   make install
 popd

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -7,7 +7,7 @@ export PERL_MM_USE_DEFAULT=1
 apt install -y build-essential && cpan -T -i Test::Nginx
 
 tar xvf libcidr-tarball/libcidr-1.2.3.tar.xz
-pushd libcidr-git
+pushd libcidr-tarball
   make
   make install
 popd

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -4,13 +4,7 @@ set -eux
 
 apt update
 export PERL_MM_USE_DEFAULT=1
-apt install -y build-essential && cpan -T -i Test::Nginx
-
-tar xvf libcidr-tarball/libcidr-1.2.3.tar.xz
-pushd libcidr-1.2.3
-  make
-  make install
-popd
+apt install -y build-essential libcidr-dev && cpan -T -i Test::Nginx
 
 release_path=$(pwd)/secureproxy-release-git-repo
 export LUA_PATH="${LUA_PATH:-};${release_path}/src/lua-libcidr-ffi/lib/?.lua"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -5,6 +5,8 @@ set -eux
 apt update
 export PERL_MM_USE_DEFAULT=1
 apt install -y build-essential && cpan -T -i Test::Nginx
+
+tar xvf libcidr-tarball/libcidr-1.2.3.tar.xz
 pushd libcidr-git
   make
   make install

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -9,7 +9,6 @@ image_resource:
 
 inputs:
 - name: secureproxy-release-git-repo
-- name: libcidr-tarball
 
 run:
   path: secureproxy-release-git-repo/ci/test.sh

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -9,7 +9,7 @@ image_resource:
 
 inputs:
 - name: secureproxy-release-git-repo
-- name: libcidr-git
+- name: libcidr-tarball
 
 run:
   path: secureproxy-release-git-repo/ci/test.sh


### PR DESCRIPTION
## Changes Proposed

- get libcidr from package manager instead of building from github repo because github repo has been removed

## Security Considerations

None, just changing the source of the `libcidr` package used for testing

This is part of the official guidance from libcidr-ffi: https://github.com/GUI/lua-libcidr-ffi#dependencies, which is the library we're using in the tests that requres `libcidr`

[The Bionic package page for `libcidr-dev`](https://packages.ubuntu.com/bionic/libcidr-dev) shows the homepage for the project as being https://www.over-yonder.net/~fullermd/projects/libcidr, which lines up with where we used to fetch it from before we switched over to using `git`: https://github.com/cloud-gov/cg-secureproxy-boshrelease/pull/27/files


