### PR TITLE
only add Content-Type header when respnose body is present

### DIFF
--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -180,12 +180,6 @@ http {
       add_header X-Content-Type-Options $content_type_options always;
       add_header X-XSS-Protection $xss_protection always;
 
-      # Don't add a `Content-Type` header if the response length is 0,
-      # e.g. 204/304 status codes
-      if ( $upstream_response_length != 0 ) {
-        add_header Content-Type $default_content_type always;
-      }
-
       # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
       more_clear_headers X-Frame-Options;
       more_set_headers "X-Frame-Options: $frame_options";
@@ -200,6 +194,14 @@ http {
       ##
 
       access_by_lua_block {
+        # Don't add a `Content-Type` header if the response length is 0,
+        # e.g. 204/304 status codes
+        if ngx.var.upstream_response_length > 0 then
+          ngx.req.set_header("Content-Type", ngx.var.default_content_type)
+        else
+          ngx.log(ngx.NOTICE, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
+        end
+
         -- bail fast if we don't have a whitelist
         if ip_whitelist_size == 0 then
           return
@@ -285,12 +287,6 @@ server {
     add_header X-Content-Type-Options $content_type_options always;
     add_header X-XSS-Protection $xss_protection always;
     
-    # Don't add a `Content-Type` header if the response length is 0,
-    # e.g. 204/304 status codes
-    if ( $upstream_response_length != 0 ) {
-      add_header Content-Type $default_content_type always;
-    }
-
     # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
     more_clear_headers X-Frame-Options;
     more_set_headers "X-Frame-Options: $frame_options";
@@ -305,6 +301,14 @@ server {
     ##
 
     access_by_lua_block {
+      # Don't add a `Content-Type` header if the response length is 0,
+      # e.g. 204/304 status codes
+      if ngx.var.upstream_response_length > 0 then
+        ngx.req.set_header("Content-Type", ngx.var.default_content_type)
+      else
+        ngx.log(ngx.NOTICE, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
+      end
+
       -- bail fast if we don't have a whitelist
       if ip_whitelist_size == 0 then
         return

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -179,7 +179,12 @@ http {
       add_header Strict-Transport-Security $sts always;
       add_header X-Content-Type-Options $content_type_options always;
       add_header X-XSS-Protection $xss_protection always;
-      add_header Content-Type $default_content_type always;
+
+      # Don't add a `Content-Type` header if the response length is 0,
+      # e.g. 204/304 status codes
+      if ( $upstream_response_length != 0 ) {
+        add_header Content-Type $default_content_type always;
+      }
 
       # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
       more_clear_headers X-Frame-Options;

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -284,7 +284,12 @@ server {
     add_header Strict-Transport-Security $sts always;
     add_header X-Content-Type-Options $content_type_options always;
     add_header X-XSS-Protection $xss_protection always;
-    add_header Content-Type $default_content_type always;
+    
+    # Don't add a `Content-Type` header if the response length is 0,
+    # e.g. 204/304 status codes
+    if ( $upstream_response_length != 0 ) {
+      add_header Content-Type $default_content_type always;
+    }
 
     # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
     more_clear_headers X-Frame-Options;


### PR DESCRIPTION
## Changes Proposed

Related to https://github.com/cloud-gov/cg-secureproxy-boshrelease/issues/81

The discussion in #81 highlights a potential bug in this proxy: it **always** adds a default `Content-Type` header to the response, even in cases like HTTP 204/304 responses which have no response body and thus for which a `Content-Type` header is inappropriate.

This PR updates the Nginx configuration to only set a default `Content-Type` header when the response body length is **not 0**, which should prevent undesirable behavior on 204/304 responses.

## Security Considerations

It seems like adding a `Content-Type` header was done to resolve a POAM: https://github.com/cloud-gov/product/issues/540

At the same time, it seems like the `Content-Type` header itself may have been an afterthought: https://github.com/cloud-gov/cg-secureproxy-boshrelease/pull/6

But for responses where the response body length is 0, I don't see how adding a `Content-Type` header is ever appropriate.
