### PR TITLE
Fix lua access block

### DIFF
--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -194,8 +194,6 @@ http {
       ##
 
       access_by_lua_block {
-        # Don't add a `Content-Type` header if the response length is 0,
-        # e.g. 204/304 status codes
         if ngx.var.upstream_response_length > 0 then
           ngx.req.set_header("Content-Type", ngx.var.default_content_type)
         else
@@ -301,8 +299,6 @@ server {
     ##
 
     access_by_lua_block {
-      # Don't add a `Content-Type` header if the response length is 0,
-      # e.g. 204/304 status codes
       if ngx.var.upstream_response_length > 0 then
         ngx.req.set_header("Content-Type", ngx.var.default_content_type)
       else

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -194,7 +194,8 @@ http {
       ##
 
       access_by_lua_block {
-        if ngx.var.upstream_response_length > 0 then
+        ngx.log(ngx.NOTICE, "Upstream response length ", ngx.var.upstream_response_length, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
+        if tonumber(ngx.var.upstream_response_length) > 0 then
           ngx.req.set_header("Content-Type", ngx.var.default_content_type)
         else
           ngx.log(ngx.NOTICE, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
@@ -299,7 +300,8 @@ server {
     ##
 
     access_by_lua_block {
-      if ngx.var.upstream_response_length > 0 then
+      ngx.log(ngx.NOTICE, "Upstream response length ", ngx.var.upstream_response_length, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
+      if tonumber(ngx.var.upstream_response_length) > 0 then
         ngx.req.set_header("Content-Type", ngx.var.default_content_type)
       else
         ngx.log(ngx.NOTICE, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")


### PR DESCRIPTION
## Changes Proposed

- Remove Lua comments with `#` which were causing these errors

    ```
    failed to load inlined Lua code: access_by_lua(nginx.conf:210):2: unexpected symbol near '#'
    ```

- Add more logging
- Update comparison for Nginx variable to cast variable as a number

## Security Considerations

See #82 
