### PR TITLE
Update Content-Type behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ blobs/*
 tmp
 my*.yml
 credentials.yml
+nginx*.conf

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ blobs/*
 tmp
 my*.yml
 credentials.yml
-nginx*.conf

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  openresty:
+    image: openresty/openresty:1.21.4.1-0-jammy
+    container_name: openresty
+    ports:
+      - 8081:8081
+    volumes:
+      - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
+    expose:
+      - "8081"
+  node:
+    build:
+      context: ./node
+    container_name: node
+    volumes:
+      - ./node/web.js:/usr/src/app/web.js
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+    ports:
+      - 3000:3000

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -93,7 +93,7 @@ http {
   map $upstream_http_content_type $default_content_type {
     '' 'text/plain; charset=utf-8';
   }
-  map $upstream_http_status $mapped_content_type {
+  map $upstream_status $mapped_content_type {
     default '$default_content_type';
     '204' '';
     '304' '';
@@ -121,13 +121,12 @@ http {
       add_header Strict-Transport-Security $sts always;
       add_header X-Content-Type-Options $content_type_options always;
       add_header X-XSS-Protection $xss_protection always;
+      add_header Content-Type $mapped_content_type always;
       
-      access_by_lua_block {
+      header_filter_by_lua_block {
         ngx.log(ngx.INFO, "host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
-        ngx.log(ngx.INFO, "upstream_http_status: ", ngx.var.upstream_http_status)
         ngx.log(ngx.INFO, "upstream_status: ", ngx.var.upstream_status)
-        ngx.log(ngx.INFO, "Status: ", ngx.var.sent_http_status)
-        ngx.log(ngx.INFO, "Upstream response length: ", ngx.var.upstream_http_response_length)
+        ngx.log(ngx.INFO, "Default content type ", ngx.var.default_content_type)
         ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type)
       }
 
@@ -143,9 +142,7 @@ http {
       proxy_pass_request_headers  on;
       proxy_connect_timeout       10;
       proxy_read_timeout          600;
-      # proxy_pass                  $backend;
       proxy_pass                  http://backend;
-
     }
   }
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,152 @@
+worker_processes 4;
+
+error_log stderr debug;
+
+worker_rlimit_nofile 40000;
+
+events {
+  worker_connections  16383;
+  multi_accept        on;
+  use                 epoll;
+}
+
+http {
+
+  ##
+  # Basic stuff
+  ##
+
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 1200;
+  types_hash_max_size 2048;
+  map_hash_bucket_size 128;
+  server_tokens off;
+
+  # see https://stackoverflow.com/a/37656784
+  resolver 127.0.0.11 ipv6=off;
+
+  default_type application/octet-stream;
+  types {
+    text/plain log;
+    text/plain asc;
+  }
+
+  ##
+  # Logging
+  ##
+
+  log_format  main  '$remote_addr - [$time_local] "$request" '
+            '$status $body_bytes_sent "$http_referer" '
+            '"$http_user_agent" $request_time '
+            '$upstream_response_time $pipe';
+
+  access_log /dev/stdout;
+
+  ##
+  # Gzip
+  ##
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_vary on;
+  gzip_types  text/plain text/css application/x-javascript application/json text/xml application/xml application/xml+rss text/javascript application/rss+xml application/javascript;
+
+
+  ##
+  # Timeout variables (currently disabled)
+  ##
+
+  client_body_timeout 10m;
+  client_max_body_size 1024m;
+
+  large_client_header_buffers 4 16k;
+
+  upstream backend {
+    server node:3000;
+  }
+
+  # Add map for websockets
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
+  # Add secure header values if not set upstream, else add headers with the
+  # implicit default value of empty string, which is ignored by the `add_header`
+  # directive.
+  map $upstream_http_strict_transport_security $sts {
+    '' 'max-age=31536000';
+  }
+  map $upstream_http_x_frame_options $frame_options {
+    default    '$upstream_http_x_frame_options';
+    ''         'DENY';
+    'ALLOWALL' '';
+  }
+  map $upstream_http_x_content_type_options $content_type_options {
+    '' 'nosniff';
+  }
+  map $upstream_http_x_xss_protection $xss_protection {
+    '' '1; mode=block';
+  }
+  map $upstream_http_content_type $default_content_type {
+    '' 'text/plain; charset=utf-8';
+  }
+  map $upstream_http_status $mapped_content_type {
+    default '$default_content_type';
+    '204' '';
+    '304' '';
+  }
+
+  include /etc/nginx/conf.d/*.conf;
+
+  server {
+    listen 8081;
+
+    # set $backend "http://node:3000";
+
+    try_files   $uri @backend;
+
+    # proxy all traffic
+    location @backend {
+
+      root   /usr/local/openresty/nginx/html;
+      index  index.html index.htm;
+
+      ##
+      # Security
+      ##
+
+      add_header Strict-Transport-Security $sts always;
+      add_header X-Content-Type-Options $content_type_options always;
+      add_header X-XSS-Protection $xss_protection always;
+      
+      access_by_lua_block {
+        ngx.log(ngx.INFO, "host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+        ngx.log(ngx.INFO, "upstream_http_status: ", ngx.var.upstream_http_status)
+        ngx.log(ngx.INFO, "upstream_status: ", ngx.var.upstream_status)
+        ngx.log(ngx.INFO, "Status: ", ngx.var.sent_http_status)
+        ngx.log(ngx.INFO, "Upstream response length: ", ngx.var.upstream_http_response_length)
+        ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type)
+      }
+
+      proxy_buffering             off;
+      proxy_buffer_size           16k;
+      proxy_buffers               4 16k;
+      proxy_http_version          1.1;
+      proxy_set_header            Upgrade $http_upgrade;
+      proxy_set_header            Connection $connection_upgrade;
+      proxy_set_header            Host $host;
+      proxy_set_header            Proxy "";
+      proxy_redirect              off;
+      proxy_pass_request_headers  on;
+      proxy_connect_timeout       10;
+      proxy_read_timeout          600;
+      # proxy_pass                  $backend;
+      proxy_pass                  http://backend;
+
+    }
+  }
+}
+

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -118,9 +118,9 @@ http {
       add_header Content-Type $mapped_content_type always;
       
       header_filter_by_lua_block {
-        ngx.log(ngx.INFO, "upstream_status: ", ngx.var.upstream_status,  " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
-        ngx.log(ngx.INFO, "Default content type ", ngx.var.default_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
-        ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+        if ngx.var.upstream_http_content_type == nil and ngx.var.mapped_content_type == "" then
+          ngx.log(ngx.INFO, "no Content-Type header")
+        end
       }
 
       proxy_buffering             off;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -63,10 +63,6 @@ http {
 
   large_client_header_buffers 4 16k;
 
-  upstream backend {
-    server node:3000;
-  }
-
   # Add map for websockets
   map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -104,12 +100,10 @@ http {
   server {
     listen 8081;
 
-    # set $backend "http://node:3000";
-
-    try_files   $uri @backend;
+    set $backend "http://node:3000";
 
     # proxy all traffic
-    location @backend {
+    location / {
 
       root   /usr/local/openresty/nginx/html;
       index  index.html index.htm;
@@ -124,10 +118,9 @@ http {
       add_header Content-Type $mapped_content_type always;
       
       header_filter_by_lua_block {
-        ngx.log(ngx.INFO, "host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
-        ngx.log(ngx.INFO, "upstream_status: ", ngx.var.upstream_status)
-        ngx.log(ngx.INFO, "Default content type ", ngx.var.default_content_type)
-        ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type)
+        ngx.log(ngx.INFO, "upstream_status: ", ngx.var.upstream_status,  " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+        ngx.log(ngx.INFO, "Default content type ", ngx.var.default_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+        ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
       }
 
       proxy_buffering             off;
@@ -142,7 +135,7 @@ http {
       proxy_pass_request_headers  on;
       proxy_connect_timeout       10;
       proxy_read_timeout          600;
-      proxy_pass                  http://backend;
+      proxy_pass                  $backend;
     }
   }
 }

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
+
+# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
+
+ARG NODE_VERSION=20.10.0
+
+FROM node:${NODE_VERSION}-alpine
+
+# Use production node environment by default.
+ENV NODE_ENV production
+
+WORKDIR /usr/src/app
+
+# Run the application as a non-root user.
+USER node
+
+# Copy the rest of the source files into the image.
+COPY . .
+
+# Expose the port that the application listens on.
+EXPOSE 3000
+
+# Run the application.
+CMD node web.js

--- a/docker/node/web.js
+++ b/docker/node/web.js
@@ -1,0 +1,17 @@
+const http = require('http');
+const os = require('os');
+const port = process.env.PORT || 5000;
+
+http.createServer( (req, res) => {
+  var url = req.url;
+
+  if (url === "/foo") {
+    res.writeHead(204);
+    res.end();
+  } else {
+    res.writeHead(200);
+    res.end(`Hello World from NodeJS on port ${port} from container ${os.hostname()}`);
+  }
+}).listen(port, () => {
+  console.log("Listening on " + port);
+});

--- a/docker/node/web.js
+++ b/docker/node/web.js
@@ -8,6 +8,14 @@ http.createServer( (req, res) => {
   if (url === "/foo") {
     res.writeHead(204);
     res.end();
+  } else if (url === "/bar") {
+    res.writeHead(304);
+    res.end();
+  } else if (url === "/html") {
+    res.writeHead(200, undefined, {
+      'Content-Type': 'text/html'
+    });
+    res.end('<h1>foobar</h1>');
   } else {
     res.writeHead(200);
     res.end(`Hello World from NodeJS on port ${port} from container ${os.hostname()}`);

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -1,7 +1,7 @@
 user  vcap vcap;
 worker_processes 4;
 
-error_log /var/vcap/sys/log/secureproxy/secureproxy.error.log notice;
+error_log /var/vcap/sys/log/secureproxy/secureproxy.error.log info;
 pid       /var/vcap/sys/run/secureproxy/secureproxy.pid;
 
 worker_rlimit_nofile 40000;
@@ -184,7 +184,6 @@ http {
       add_header Strict-Transport-Security $sts always;
       add_header X-Content-Type-Options $content_type_options always;
       add_header X-XSS-Protection $xss_protection always;
-      add_header Content-Type $default_content_type always;
 
       # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
       more_clear_headers X-Frame-Options;
@@ -200,6 +199,13 @@ http {
       ##
 
       access_by_lua_block {
+        ngx.log(ngx.INFO, "Upstream response length ", ngx.var.upstream_response_length, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
+        if tonumber(ngx.var.upstream_response_length) > 0 then
+          ngx.req.set_header("Content-Type", ngx.var.default_content_type)
+        else
+          ngx.log(ngx.INFO, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
+        end
+
         -- bail fast if we don't have a whitelist
         if ip_whitelist_size == 0 then
           return
@@ -284,7 +290,6 @@ server {
     add_header Strict-Transport-Security $sts always;
     add_header X-Content-Type-Options $content_type_options always;
     add_header X-XSS-Protection $xss_protection always;
-    add_header Content-Type $default_content_type always;
     
     # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
     more_clear_headers X-Frame-Options;
@@ -300,6 +305,15 @@ server {
     ##
 
     access_by_lua_block {
+      ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
+
+      ngx.log(ngx.INFO, "Upstream response length ", ngx.var.upstream_response_length, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
+      if tonumber(ngx.var.upstream_response_length) > 0 then
+        ngx.req.set_header("Content-Type", ngx.var.default_content_type)
+      else
+        ngx.log(ngx.INFO, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
+      end
+
       -- bail fast if we don't have a whitelist
       if ip_whitelist_size == 0 then
         return

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -1,7 +1,7 @@
 user  vcap vcap;
 worker_processes 4;
 
-error_log /var/vcap/sys/log/secureproxy/secureproxy.error.log info;
+error_log /var/vcap/sys/log/secureproxy/secureproxy.error.log notice;
 pid       /var/vcap/sys/run/secureproxy/secureproxy.pid;
 
 worker_rlimit_nofile 40000;
@@ -293,10 +293,6 @@ server {
     add_header Content-Type $mapped_content_type always;
 
     header_filter_by_lua_block {
-      ngx.log(ngx.INFO, "Upstream content type: ", ngx.var.upstream_http_content_type)
-      ngx.log(ngx.INFO, "Default content type: ", ngx.var.default_content_type)
-      ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type)
-      
       if ngx.var.upstream_http_content_type == nil and ngx.var.mapped_content_type == "" then
         ngx.log(ngx.INFO, "no Content-Type header")
       end

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -184,6 +184,7 @@ http {
       add_header Strict-Transport-Security $sts always;
       add_header X-Content-Type-Options $content_type_options always;
       add_header X-XSS-Protection $xss_protection always;
+      add_header Content-Type $mapped_content_type always;
 
       # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
       more_clear_headers X-Frame-Options;
@@ -194,18 +195,17 @@ http {
       more_set_headers "<%= csp_header %>: $content_security_policy";
       <% end %>
 
+      header_filter_by_lua_block {
+        ngx.log(ngx.INFO, "upstream_status: ", ngx.var.upstream_status,  " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+        ngx.log(ngx.INFO, "Default content type ", ngx.var.default_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+        ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+      }
+
       ##
       # Implement per-domain IP Whitelist
       ##
 
       access_by_lua_block {
-        ngx.log(ngx.INFO, "Upstream response length ", ngx.var.upstream_response_length, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
-        if tonumber(ngx.var.upstream_response_length) > 0 then
-          ngx.req.set_header("Content-Type", ngx.var.default_content_type)
-        else
-          ngx.log(ngx.INFO, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
-        end
-
         -- bail fast if we don't have a whitelist
         if ip_whitelist_size == 0 then
           return
@@ -290,6 +290,13 @@ server {
     add_header Strict-Transport-Security $sts always;
     add_header X-Content-Type-Options $content_type_options always;
     add_header X-XSS-Protection $xss_protection always;
+    add_header Content-Type $mapped_content_type always;
+
+    header_filter_by_lua_block {
+      ngx.log(ngx.INFO, "upstream_status: ", ngx.var.upstream_status,  " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+      ngx.log(ngx.INFO, "Default content type ", ngx.var.default_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+      ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+    }
     
     # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
     more_clear_headers X-Frame-Options;
@@ -305,15 +312,6 @@ server {
     ##
 
     access_by_lua_block {
-      ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
-
-      ngx.log(ngx.INFO, "Upstream response length ", ngx.var.upstream_response_length, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
-      if tonumber(ngx.var.upstream_response_length) > 0 then
-        ngx.req.set_header("Content-Type", ngx.var.default_content_type)
-      else
-        ngx.log(ngx.INFO, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
-      end
-
       -- bail fast if we don't have a whitelist
       if ip_whitelist_size == 0 then
         return

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -196,9 +196,9 @@ http {
       <% end %>
 
       header_filter_by_lua_block {
-        ngx.log(ngx.INFO, "upstream_status: ", ngx.var.upstream_status,  " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
-        ngx.log(ngx.INFO, "Default content type ", ngx.var.default_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
-        ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+        if ngx.var.upstream_http_content_type == nil and ngx.var.mapped_content_type == "" then
+          ngx.log(ngx.INFO, "no Content-Type header")
+        end
       }
 
       ##
@@ -293,9 +293,9 @@ server {
     add_header Content-Type $mapped_content_type always;
 
     header_filter_by_lua_block {
-      ngx.log(ngx.INFO, "upstream_status: ", ngx.var.upstream_status,  " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
-      ngx.log(ngx.INFO, "Default content type ", ngx.var.default_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
-      ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type, " host: ", ngx.var.host, " ,request URI ", ngx.var.request_uri)
+      if ngx.var.upstream_http_content_type == nil and ngx.var.mapped_content_type == "" then
+        ngx.log(ngx.INFO, "no Content-Type header")
+      end
     }
     
     # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -195,6 +195,14 @@ http {
       ##
 
       access_by_lua_block {
+        ngx.log(ngx.NOTICE, "Upstream response length ", ngx.var.upstream_response_length, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
+        if ngx.var.upstream_status == "204" then
+          ngx.log(ngx.NOTICE, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
+        else
+          ngx.req.set_header("Content-Type", ngx.var.default_content_type)
+        end
+        ngx.req.set_header("foo", "bar")
+
         -- bail fast if we don't have a whitelist
         if ip_whitelist_size == 0 then
           return
@@ -295,6 +303,14 @@ server {
     ##
 
     access_by_lua_block {
+      ngx.log(ngx.NOTICE, "Upstream response length ", ngx.var.upstream_response_length, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
+      if ngx.var.upstream_status == "204" then
+        ngx.log(ngx.NOTICE, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
+      else
+        ngx.req.set_header("Content-Type", ngx.var.default_content_type)
+      end
+      ngx.req.set_header("foo", "bar")
+
       -- bail fast if we don't have a whitelist
       if ip_whitelist_size == 0 then
         return

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -284,7 +284,7 @@ server {
     add_header Strict-Transport-Security $sts always;
     add_header X-Content-Type-Options $content_type_options always;
     add_header X-XSS-Protection $xss_protection always;
-    add_header Content-Type $mapped_content_type always;
+    add_header Content-Type $default_content_type always;
     
     # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
     more_clear_headers X-Frame-Options;

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -105,7 +105,7 @@ http {
     '' 'text/plain; charset=utf-8';
   }
   map $upstream_status $mapped_content_type {
-    default '$default_content_type'
+    default '$default_content_type';
     '204' '';
     '304' '';
   }

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -104,6 +104,11 @@ http {
   map $upstream_http_content_type $default_content_type {
     '' 'text/plain; charset=utf-8';
   }
+  map $upstream_status $mapped_content_type {
+    default '$default_content_type'
+    '204' '';
+    '304' '';
+  }
 
   <% if p('secureproxy.csp.enable') %>
   # right now, we're doing this with report-only. later, we'll drop report-only and move to enforce with report
@@ -179,7 +184,7 @@ http {
       add_header Strict-Transport-Security $sts always;
       add_header X-Content-Type-Options $content_type_options always;
       add_header X-XSS-Protection $xss_protection always;
-      add_header Content-Type $default_content_type always;
+      add_header Content-Type $mapped_content_type always;
 
       # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
       more_clear_headers X-Frame-Options;
@@ -195,14 +200,6 @@ http {
       ##
 
       access_by_lua_block {
-        ngx.log(ngx.NOTICE, "Upstream response length ", ngx.var.upstream_response_length, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
-        if ngx.var.upstream_status == "204" then
-          ngx.log(ngx.NOTICE, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
-        else
-          ngx.req.set_header("Content-Type", ngx.var.default_content_type)
-        end
-        ngx.req.set_header("foo", "bar")
-
         -- bail fast if we don't have a whitelist
         if ip_whitelist_size == 0 then
           return
@@ -287,7 +284,7 @@ server {
     add_header Strict-Transport-Security $sts always;
     add_header X-Content-Type-Options $content_type_options always;
     add_header X-XSS-Protection $xss_protection always;
-    add_header Content-Type $default_content_type always;
+    add_header Content-Type $mapped_content_type always;
     
     # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
     more_clear_headers X-Frame-Options;
@@ -303,14 +300,6 @@ server {
     ##
 
     access_by_lua_block {
-      ngx.log(ngx.NOTICE, "Upstream response length ", ngx.var.upstream_response_length, " for host ", ngx.var.host, "and request URI ", ngx.var.request_uri)
-      if ngx.var.upstream_status == "204" then
-        ngx.log(ngx.NOTICE, "Content-Type header not added for host ", ngx.var.host, "and request URI ", ngx.var.request_uri , "with a response body length of 0")
-      else
-        ngx.req.set_header("Content-Type", ngx.var.default_content_type)
-      end
-      ngx.req.set_header("foo", "bar")
-
       -- bail fast if we don't have a whitelist
       if ip_whitelist_size == 0 then
         return

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -184,7 +184,7 @@ http {
       add_header Strict-Transport-Security $sts always;
       add_header X-Content-Type-Options $content_type_options always;
       add_header X-XSS-Protection $xss_protection always;
-      add_header Content-Type $mapped_content_type always;
+      add_header Content-Type $default_content_type always;
 
       # Clear X-Frame-Options before setting so that ALLOWALL is cleared if set
       more_clear_headers X-Frame-Options;

--- a/jobs/secureproxy/templates/config/nginx.conf.erb
+++ b/jobs/secureproxy/templates/config/nginx.conf.erb
@@ -293,6 +293,10 @@ server {
     add_header Content-Type $mapped_content_type always;
 
     header_filter_by_lua_block {
+      ngx.log(ngx.INFO, "Upstream content type: ", ngx.var.upstream_http_content_type)
+      ngx.log(ngx.INFO, "Default content type: ", ngx.var.default_content_type)
+      ngx.log(ngx.INFO, "Mapped content type ", ngx.var.mapped_content_type)
+      
       if ngx.var.upstream_http_content_type == nil and ngx.var.mapped_content_type == "" then
         ngx.log(ngx.INFO, "no Content-Type header")
       end


### PR DESCRIPTION
## Changes Proposed

Related to https://github.com/cloud-gov/cg-secureproxy-boshrelease/issues/81

The discussion in #81 highlights a potential bug in this proxy: it **always** adds a default `Content-Type` header to the response, even in cases like HTTP 204/304 responses which have no response body and thus for which a `Content-Type` header is inappropriate.

This PR updates the Nginx configuration to only set a default `Content-Type` header when the response status code is not 204 or 304.

The PR also adds some Docker configuration for running OpenResty with a basic Node app to make local testing much easier.

## Security Considerations

It seems like adding a `Content-Type` header was done to resolve a POAM: https://github.com/cloud-gov/product/issues/540

At the same time, it seems like the `Content-Type` header itself may have been an afterthought: https://github.com/cloud-gov/cg-secureproxy-boshrelease/pull/6

But for 204/304 responses where no response body is expected, I don't see how adding a `Content-Type` header is ever appropriate.
