### PR TITLE
use fips endpoint for blobstore

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -3,4 +3,5 @@ blobstore:
   provider: s3
   options:
     bucket_name: secureproxy-boshrelease
+    host: s3-fips.us-gov-west-1.amazonaws.com
 final_name: secureproxy


### PR DESCRIPTION
## Changes Proposed

- Set the host property to the fips endpoint

## Security Considerations

Instructs bosh to use the fips 140 compliant fips endpoint when interacting with S3.
